### PR TITLE
Much better way to have reactive helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ to formatting and other utilities.
   meteor add lbee:moment-helpers
 ```
 
+## Reactivity
+In order to get reactive helpers modifying the results according to current locale,
+you must use `mo.setLocale` instead of `moment.locale` whenever you want to change
+locale dynamically.
+
 ## Examples
 
 ### moFormat

--- a/client.js
+++ b/client.js
@@ -1,21 +1,13 @@
 "use strict";
 
 var currentLocale = new ReactiveVar();
+
 currentLocale.set(moment.locale());
 
-var originalLocale = moment.locale;
-
-moment.locale = function(key, values){
-  var locale = originalLocale(key, values);
-
-  if (key) {
-    if (typeof(values) === 'undefined') {
-      currentLocale.set(locale);
-    }
-  }
-
-  return locale;
-}
+mo.setLocale = function(locale){
+  moment.locale(locale);
+  currentLocale.set(moment.locale());
+};
 
 Template.registerHelper('moFormat', function () {
   // Calling this reactive property ensure the helper is updated whenever the


### PR DESCRIPTION
Overriding moment methods was ugly.

This PR provide a new `mo.setLocale` method which will call `moment.locale` and update the reactive var used in helpers.
